### PR TITLE
Fix account switcher menu button

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   "engines": {
     "nylas": "*"
   },
-  "styleSheets": ["email-frame"],
+  "styleSheets": ["email-frame", "sidebar"],
   "private": true
 }

--- a/styles/sidebar.less
+++ b/styles/sidebar.less
@@ -1,0 +1,3 @@
+.account-switcher img {
+    -webkit-filter: invert();
+}


### PR DESCRIPTION
The account switcher is really difficult to see on the dark background.

This PR applies the `invert` CSS filter to make it more visible without making it obtrusive.

### Before:
![image](https://cloud.githubusercontent.com/assets/1521802/26563038/1e5e1482-44c4-11e7-8b46-9154e5336a47.png)

### After:
![image](https://cloud.githubusercontent.com/assets/1521802/26563041/32bf605c-44c4-11e7-80c8-03d31f490a80.png)
